### PR TITLE
Use a unique header file name

### DIFF
--- a/TFT_Touch_Shield_V1.h
+++ b/TFT_Touch_Shield_V1.h
@@ -1,0 +1,1 @@
+#include "TFT.h"

--- a/examples/drawCircle/drawCircle.ino
+++ b/examples/drawCircle/drawCircle.ino
@@ -14,7 +14,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h>
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/drawLines/drawLines.ino
+++ b/examples/drawLines/drawLines.ino
@@ -14,7 +14,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h> 
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/drawRectangle/drawRectangle.ino
+++ b/examples/drawRectangle/drawRectangle.ino
@@ -14,7 +14,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h> 
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/paint/paint.ino
+++ b/examples/paint/paint.ino
@@ -14,7 +14,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h>
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) // mega

--- a/examples/shapes/shapes.ino
+++ b/examples/shapes/shapes.ino
@@ -14,7 +14,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h>
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/text/text.ino
+++ b/examples/text/text.ino
@@ -15,7 +15,7 @@
 
 #include <stdint.h>
 #include <TouchScreen.h> 
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/text4Directions/text4Directions.ino
+++ b/examples/text4Directions/text4Directions.ino
@@ -18,7 +18,7 @@
 */
 #include <stdint.h>
 #include <TouchScreen.h> 
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!

--- a/examples/tftbmp/tftbmp.ino
+++ b/examples/tftbmp/tftbmp.ino
@@ -1,7 +1,7 @@
 // Tft Touch Shield V1.0 demo - Display BMP file
 
 #include <SD.h>
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 
 // In the SD card, place 24 bit color BMP files (be sure they are 24-bit!)
 // the file itself

--- a/examples/touchscreendemo/touchscreendemo.ino
+++ b/examples/touchscreendemo/touchscreendemo.ino
@@ -13,7 +13,7 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <stdint.h>
 #include <TouchScreen.h> 
-#include <TFT.h>
+#include <TFT_Touch_Shield_V1.h>
 #ifdef SEEEDUINO
   #define YP A2   // must be an analog pin, use "An" notation!
   #define XM A1   // must be an analog pin, use "An" notation!


### PR DESCRIPTION
The Arduino IDE comes with a TFT library which contains a file named TFT.h. When multiple libraries are found that match an #include directive, the Arduino IDE gives preference to the one whose folder name matches the header file name. That meant the Arduino TFT library is `#include`d instead of this library, causing compilation to fail. For this reason, it was previously impossible to use this library without first deleting the official Arduino TFT library.

To solve this issue, a header file with a unique name was added to the library, and the example sketches updated to use that file name in their #include directives.